### PR TITLE
added support for Joplin v1.4.19

### DIFF
--- a/org.joplinapp.joplin/org.joplinapp.joplin.yaml
+++ b/org.joplinapp.joplin/org.joplinapp.joplin.yaml
@@ -44,7 +44,6 @@ modules:
           - rm -f appimage
           - rm -f squashfs-root/{AppRun,.DirIcon,joplin.desktop,joplin.png}
           - rm -rf squashfs-root/usr
-          - ls squashfs-root/
           - mv squashfs-root/* ./
           - rmdir squashfs-root
       - type: extra-data

--- a/org.joplinapp.joplin/org.joplinapp.joplin.yaml
+++ b/org.joplinapp.joplin/org.joplinapp.joplin.yaml
@@ -42,15 +42,16 @@ modules:
         commands:
           - unappimage appimage
           - rm -f appimage
-          - rm -f squashfs-root/{.DirIcon,AppRun,joplin.desktop,joplin.png}
+          - rm -f squashfs-root/{AppRun,.DirIcon,joplin.desktop,joplin.png}
           - rm -rf squashfs-root/usr
+          - ls squashfs-root/
           - mv squashfs-root/* ./
           - rmdir squashfs-root
       - type: extra-data
         filename: appimage
-        url: https://github.com/laurent22/joplin/releases/download/v1.3.18/Joplin-1.3.18.AppImage
-        sha256: c7e962599352057b4675a74fc2ab854b844a75c1bf97761cec18a97846f08db6
-        size: 123383014
+        url: https://github.com/laurent22/joplin/releases/download/v1.4.19/Joplin-1.4.19.AppImage
+        sha256: f2492e5e3b72cab0c1f4c481135a423b14d87529697145e082ec336a2f18d2f7
+        size: 145773103
       - type: dir
         path: resources
     modules:

--- a/org.joplinapp.joplin/resources/joplin
+++ b/org.joplinapp.joplin/resources/joplin
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 export TMPDIR=$XDG_RUNTIME_DIR/app/$FLATPAK_ID
-ls /app/extra
 exec zypak-wrapper /app/extra/@joplinapp-desktop "$@"

--- a/org.joplinapp.joplin/resources/joplin
+++ b/org.joplinapp.joplin/resources/joplin
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 export TMPDIR=$XDG_RUNTIME_DIR/app/$FLATPAK_ID
-
-exec zypak-wrapper /app/extra/joplin "$@"
+ls /app/extra
+exec zypak-wrapper /app/extra/@joplinapp-desktop "$@"


### PR DESCRIPTION
I don't know why but simply linking to the other AppImage wasn't enough, I got this error that the joplin-binary wasn't found.
After some fiddling around (and getting to know Flatpak myself) I managed to fix it.